### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/Components/teams/TeamImageUploader.jsx
+++ b/src/Components/teams/TeamImageUploader.jsx
@@ -21,6 +21,7 @@ const TeamImageUploader = ({ profilePicFromApi, setToast, setIsLoading }) => {
       const isSvg = file.type === "image/svg+xml" || (file.name && file.name.toLowerCase().endsWith(".svg"));
       if (isSvg) {
         setToast({ message: "SVG files are not allowed for security reasons.", type: "error" });
+        e.target.value = '';
         return;
       }
       setSelectedFile(file);

--- a/src/Components/teams/TeamImageUploader.jsx
+++ b/src/Components/teams/TeamImageUploader.jsx
@@ -17,6 +17,12 @@ const TeamImageUploader = ({ profilePicFromApi, setToast, setIsLoading }) => {
   const handleFileChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      // Block SVG files for security
+      const isSvg = file.type === "image/svg+xml" || (file.name && file.name.toLowerCase().endsWith(".svg"));
+      if (isSvg) {
+        setToast({ message: "SVG files are not allowed for security reasons.", type: "error" });
+        return;
+      }
       setSelectedFile(file);
       setPreviewImage(URL.createObjectURL(file));
     }


### PR DESCRIPTION
Potential fix for [https://github.com/TaskTrial/client/security/code-scanning/3](https://github.com/TaskTrial/client/security/code-scanning/3)

To fix the issue, we should ensure that only safe image types are accepted and processed. The best way is to validate the file type in the `handleFileChange` function before creating a preview. Specifically, we should reject SVG files, as they can contain embedded scripts that may be executed when rendered as an image. This can be done by checking the MIME type and/or file extension of the selected file. The fix should be applied in the `handleFileChange` function in `src/Components/teams/TeamImageUploader.jsx`, by adding a check to prevent SVG files from being previewed or uploaded.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
