### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/Components/organization/OrganizationImageUploader.jsx
+++ b/src/Components/organization/OrganizationImageUploader.jsx
@@ -21,6 +21,10 @@ const OrganizationImageUploader = ({
   const handleFileChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (!file.type.startsWith("image/")) {
+        setToast({ message: "Only image files are allowed.", type: "error" });
+        return;
+      }
       setSelectedFile(file);
       setPreviewImage(URL.createObjectURL(file));
     }


### PR DESCRIPTION
Potential fix for [https://github.com/TaskTrial/client/security/code-scanning/2](https://github.com/TaskTrial/client/security/code-scanning/2)

The best way to address this issue, without changing application functionality, is to add explicit client-side validation to ensure that only genuine image files are accepted and previewed. This means updating the `handleFileChange` function so that it checks the MIME type of the selected file before setting it as the preview image. The fix should reject non-image files and alert the user. The fix should be implemented in `src/Components/organization/OrganizationImageUploader.jsx`, specifically in the `handleFileChange` function (lines 21-27).

If not already present, browser-based validation can be enforced by checking `file.type` and ensuring it starts with `image/`; if it does not, show an error (e.g., via `setToast`), and do not update the preview image nor the selected file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
