### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/Components/Auser/ProfileImageUploader.jsx
+++ b/src/Components/Auser/ProfileImageUploader.jsx
@@ -142,9 +142,22 @@ const ProfileImageUploader = ({
 
   const imageToDisplay = previewImage || currentPic;
 
+  // Helper function to check for safe image URLs
+  function isSafeImageSrc(src) {
+    if (!src || typeof src !== "string") return false;
+    // Allow blob URLs
+    if (src.startsWith("blob:")) return true;
+    // Allow data URLs only for images
+    if (src.startsWith("data:image/")) return true;
+    // Allow http or https URLs with common image extensions
+    if (/^https?:\/\/.+\.(jpg|jpeg|png|gif|bmp|webp|svg)$/i.test(src)) return true;
+    // Reject all others for safety
+    return false;
+  }
+
   return (
     <div className="editProfile-avatar-section">
-      {imageToDisplay ? (
+      {isSafeImageSrc(imageToDisplay) ? (
         <img
           src={imageToDisplay}
           alt="Profile"


### PR DESCRIPTION
Potential fix for [https://github.com/TaskTrial/client/security/code-scanning/1](https://github.com/TaskTrial/client/security/code-scanning/1)

**General Fix:**  
Ensure that untrusted content is not directly assigned as the `src` attribute of an `<img>` unless it is strictly validated. Only allow `src` values that are either `URL.createObjectURL` blobs or trusted domains, and never allow `javascript:` or dangerous `data:` URIs.

**Best Fix for this code:**  
*Sanitize* the value of `imageToDisplay` before setting it as the `src` attribute in `<img>`. Implement a function—e.g., `isSafeImageSrc(src)`—that checks if the URL is a `blob:` URL (as returned by `URL.createObjectURL`), a data URL with an image mime type (`data:image/`), or a regular http(s) image URL (with optional image extension check), and prevents unsafe values.

- Prior to rendering the `<img>`, run `isSafeImageSrc(imageToDisplay)`.
- If unsafe, fall back to the icon or do not display the image.
- Define this helper function in the same file.
- No additional imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
