### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/Components/Auser/ProfileImageUploader.jsx
+++ b/src/Components/Auser/ProfileImageUploader.jsx
@@ -22,6 +22,18 @@ const ProfileImageUploader = ({
   const handleFileChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      // Block SVG files (extra defense)
+      if (
+        file.type === "image/svg+xml" ||
+        (file.name && file.name.toLowerCase().endsWith(".svg"))
+      ) {
+        setToast &&
+          setToast({
+            type: "error",
+            message: "SVG images are not allowed for profile pictures.",
+          });
+        return;
+      }
       setSelectedFile(file);
       setPreviewImage(URL.createObjectURL(file));
     }
@@ -142,15 +154,17 @@ const ProfileImageUploader = ({
 
   const imageToDisplay = previewImage || currentPic;
 
-  // Helper function to check for safe image URLs
+  // Helper function to check for safe image URLs (block SVG)
   function isSafeImageSrc(src) {
     if (!src || typeof src !== "string") return false;
-    // Allow blob URLs
+    // Block SVG images for security reasons (SVG can contain script)
+    if (src.endsWith('.svg') || src.toLowerCase().includes('image/svg+xml')) return false;
+    // Allow blob URLs (non-svg checked above)
     if (src.startsWith("blob:")) return true;
-    // Allow data URLs only for images
-    if (src.startsWith("data:image/")) return true;
-    // Allow http or https URLs with common image extensions
-    if (/^https?:\/\/.+\.(jpg|jpeg|png|gif|bmp|webp|svg)$/i.test(src)) return true;
+    // Allow data URLs only for images except SVG
+    if (/^data:image\/(?!svg\+xml)[a-z0-9.+-]+/i.test(src)) return true;
+    // Allow http or https URLs with common image extensions (except svg)
+    if (/^https?:\/\/.+\.(jpg|jpeg|png|gif|bmp|webp)$/i.test(src)) return true;
     // Reject all others for safety
     return false;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/TaskTrial/client/security/code-scanning/1](https://github.com/TaskTrial/client/security/code-scanning/1)

To securely guard against this XSS vector while preserving all functionality, we need to update the code to prevent SVG images being uploaded and displayed as profile pictures. This should apply both to the `isSafeImageSrc` function and to the `<input accept="image/*">` attribute (although the browser's UI filter is not sufficient). We'll:
- Update the `isSafeImageSrc` function to reject any image with the type `.svg` or with `data:image/svg+xml`.
- Optionally, update the file selection handler `handleFileChange` to block SVG as well (for additional defense-in-depth).
- Keep the image rendering conditional, unchanged otherwise.

No additional packages are needed, and the approach is to locally harden the validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
