### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/Components/organization/OrganizationImageUploader.jsx
+++ b/src/Components/organization/OrganizationImageUploader.jsx
@@ -145,7 +145,23 @@ const OrganizationImageUploader = ({
     }
   };
 
-  const imageToDisplay = previewImage || currentPic;
+  // Accept only blob URLs (for preview) or trusted static URLs (from backend)
+  const isValidImageUrl = (url) => {
+    if (!url || typeof url !== "string") return false;
+    // Accept blob/object URLs created by the browser
+    if (url.startsWith("blob:")) return true;
+    // Accept URLs from trusted backends (adjust regex or domains as appropriate)
+    if (
+      url.startsWith("http://localhost:3000/") ||
+      url.startsWith("https://localhost:3000/") ||
+      url.startsWith("https://your-trusted-cdn.com/") // Add more trusted image origins
+    )
+      return true;
+    return false;
+  };
+
+  const rawImage = previewImage || currentPic;
+  const imageToDisplay = isValidImageUrl(rawImage) ? rawImage : null;
 
   return (
     <div className="editProfile-avatar-section">


### PR DESCRIPTION
Potential fix for [https://github.com/TaskTrial/client/security/code-scanning/2](https://github.com/TaskTrial/client/security/code-scanning/2)

The best way to fix this is to ensure that `imageToDisplay` is strictly either a blob/object URL (from `URL.createObjectURL`) or a validated image URL (e.g., from a trusted backend). Validation should be done before passing any string to the `src` attribute, ensuring it matches the expected pattern: either a blob/object URL (begins with `blob:`) or a trusted domain (e.g., your API's CDN/image base URL). This avoids DOM text being reinterpreted as HTML by preventing attacker-provided arbitrary URLs or code from being injected.

**Specifically:**  
Add a utility function to validate that the URL is either a `blob:` URL or matches a known trusted base (e.g., starts with `http://localhost:3000/` or a CDN). Use this function to filter or ignore invalid URLs before assigning to `src`.

- Add the validator function in `OrganizationImageUploader.jsx`.
- Use the validator when setting `imageToDisplay`.
- If the URL is invalid, fall back to `null` (which will default to the icon).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
