### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/Components/Auser/ProfileImageUploader.jsx
+++ b/src/Components/Auser/ProfileImageUploader.jsx
@@ -22,15 +22,22 @@ const ProfileImageUploader = ({
   const handleFileChange = (e) => {
     const file = e.target.files[0];
     if (file) {
-      // Block SVG files (extra defense)
+      // Only allow safe image MIME types (extra defense)
+      const allowedTypes = [
+        "image/jpeg",
+        "image/png",
+        "image/gif",
+        "image/bmp",
+        "image/webp"
+      ];
       if (
-        file.type === "image/svg+xml" ||
+        !allowedTypes.includes(file.type) ||
         (file.name && file.name.toLowerCase().endsWith(".svg"))
       ) {
         setToast &&
           setToast({
             type: "error",
-            message: "SVG images are not allowed for profile pictures.",
+            message: "Only JPEG, PNG, GIF, BMP, or WEBP images are allowed for profile pictures.",
           });
         return;
       }
@@ -158,17 +165,23 @@ const ProfileImageUploader = ({
   function isSafeImageSrc(src) {
     if (!src || typeof src !== "string") return false;
     // Block SVG images for security reasons (SVG can contain script)
-    if (src.endsWith('.svg') || src.toLowerCase().includes('image/svg+xml')) return false;
-    // Allow blob URLs (non-svg checked above)
+    if (
+      src.endsWith('.svg') ||
+      src.toLowerCase().includes('image/svg+xml') ||
+      src.toLowerCase().includes('svg%3') // Encoded SVG
+    ) return false;
+    // Allow blob URLs -- checked above for SVG
     if (src.startsWith("blob:")) return true;
-    // Allow data URLs only for images except SVG
-    if (/^data:image\/(?!svg\+xml)[a-z0-9.+-]+/i.test(src)) return true;
+    // Allow data URLs for safe image types only (jpeg, png, gif, bmp, webp)
+    if (/^data:image\/(jpeg|png|gif|bmp|webp);base64,/i.test(src)) return true;
     // Allow http or https URLs with common image extensions (except svg)
     if (/^https?:\/\/.+\.(jpg|jpeg|png|gif|bmp|webp)$/i.test(src)) return true;
     // Reject all others for safety
     return false;
   }
 
+          referrerPolicy="no-referrer"
+          crossOrigin="anonymous"
   return (
     <div className="editProfile-avatar-section">
       {isSafeImageSrc(imageToDisplay) ? (


### PR DESCRIPTION
Potential fix for [https://github.com/TaskTrial/client/security/code-scanning/1](https://github.com/TaskTrial/client/security/code-scanning/1)

To further harden the code, we should ensure that the `src` attribute of the `<img>` element never references an SVG file, and, ideally, the browser never attempts to interpret SVG or other non-image formats as images. The current code already blocks SVG files via MIME type and extension checks, and with a `isSafeImageSrc` helper. To further mitigate possible bypasses (e.g., a file with a spoofed MIME type), we should (a) extend the file validation in `handleFileChange` to reject any file where the content-type is not a "safe image" (like JPEG, PNG, GIF, WEBP, BMP) using a whitelist; and (b) tighten the checks in `isSafeImageSrc` to avoid edge cases not covered by the current regex.

Changes will be made:
1. Update `handleFileChange` (lines 22–40) to rely on a whitelist of allowed MIME types instead of only checking for disallowed SVG.
2. Update `isSafeImageSrc` (lines 158–170) to further restrict to safe image types using mime-type matching.
3. Optionally, set the `referrerPolicy="no-referrer"` and `crossOrigin="anonymous"` attrs on the `<img>` for further defense.

No additional libraries are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
