### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/Components/teams/TeamImageUploader.jsx
+++ b/src/Components/teams/TeamImageUploader.jsx
@@ -17,15 +17,25 @@ const TeamImageUploader = ({ profilePicFromApi, setToast, setIsLoading }) => {
   const handleFileChange = (e) => {
     const file = e.target.files[0];
     if (file) {
-      // Block SVG files for security
-      const isSvg = file.type === "image/svg+xml" || (file.name && file.name.toLowerCase().endsWith(".svg"));
-      if (isSvg) {
-        setToast({ message: "SVG files are not allowed for security reasons.", type: "error" });
-        e.target.value = '';
-        return;
-      }
-      setSelectedFile(file);
-      setPreviewImage(URL.createObjectURL(file));
+      // Block SVG files for security, including by scanning contents for '<svg'
+      const isSvgType = file.type === "image/svg+xml" || (file.name && file.name.toLowerCase().endsWith(".svg"));
+      const reader = new FileReader();
+      reader.onload = function(ev) {
+        const content = ev.target.result;
+        // Scan for <svg opening tag in the file's text content
+        if (isSvgType || (typeof content === 'string' && content.trim().toLowerCase().startsWith('<svg'))) {
+          setToast({ message: "SVG files are not allowed for security reasons.", type: "error" });
+          e.target.value = '';
+          return;
+        }
+        setSelectedFile(file);
+        setPreviewImage(URL.createObjectURL(file));
+      };
+      
+      // Only read as text if the file is small (images often are), otherwise fallback or skip for larger files
+      // Read first kilobyte for inspection without heavy cost
+      const blob = file.slice(0, 1024);
+      reader.readAsText(blob);
     }
   };
 


### PR DESCRIPTION
Potential fix for [https://github.com/TaskTrial/client/security/code-scanning/3](https://github.com/TaskTrial/client/security/code-scanning/3)

To robustly fix this issue, enhance the SVG file type check in `handleFileChange` to inspect the contents of the uploaded file rather than relying solely on MIME type or extension, as attackers can easily spoof these attributes. This prevents SVGs containing embedded scripts from being uploaded and rendered via the `src` attribute, eliminating the browser's opportunity to interpret any attacker-controlled markup.

**Steps:**
- Extend the SVG detection in `handleFileChange`: After the initial blocking for type and extension, read the first few bytes of the file and check for the `<svg` tag. If found, reject the file.
- This should be a synchronous or asynchronous check before setting the preview image and selected file variables.
- No need to escape meta-characters for Blob URLs, as they're opaque references, so the core concern is preventing scriptable SVGs or malicious files.

**Required Changes:**
- Modify the file block in `handleFileChange` to perform content inspection after type/extension checks.
- This change is contained within `src/Components/teams/TeamImageUploader.jsx`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
