### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/Components/Auser/ProfileImageUploader.jsx
+++ b/src/Components/Auser/ProfileImageUploader.jsx
@@ -30,10 +30,18 @@ const ProfileImageUploader = ({
         "image/bmp",
         "image/webp"
       ];
+      // Check for allowed types, and block SVG in type, ext, or mimetype (double check)
+      const isSvgType = (file.type && file.type.toLowerCase().includes("svg"));
+      const isSvgExt = (file.name && file.name.toLowerCase().endsWith(".svg"));
+      const isSvgMime = (file.type && file.type.toLowerCase().includes("image/svg+xml"));
       if (
         !allowedTypes.includes(file.type) ||
-        (file.name && file.name.toLowerCase().endsWith(".svg"))
+        isSvgType ||
+        isSvgExt ||
+        isSvgMime
       ) {
+        setSelectedFile(null);
+        setPreviewImage(null);
         setToast &&
           setToast({
             type: "error",
@@ -186,6 +194,8 @@ const ProfileImageUploader = ({
     <div className="editProfile-avatar-section">
       {isSafeImageSrc(imageToDisplay) ? (
         <img
+          referrerPolicy="no-referrer"
+          crossOrigin="anonymous"
           src={imageToDisplay}
           alt="Profile"
           className="editProfile-avatar"


### PR DESCRIPTION
Potential fix for [https://github.com/TaskTrial/client/security/code-scanning/1](https://github.com/TaskTrial/client/security/code-scanning/1)

The recommended fix is to strictly enforce allowed image types and sources before setting any preview or rendering the image. Specifically:

1. Continue to block SVG and only allow certain MIME types **and** extensions.
2. Ensure that `URL.createObjectURL(file)` can't be abused—Object URLs are generally safe as long as you only pass user-uploaded files, but adding a fallback HTML escaping is prudent.
3. **Best fix:** Refactor the file selection and preview logic so that only allowed image files (excluding SVG, etc.) are previewed (i.e., set as `previewImage`), and only safe URLs are ever assigned to the `src`. You may harden `handleFileChange` to *never* set a preview for files that aren't strictly allowed, so the preview never stores a tainted value. 
4. Double-check that `isSafeImageSrc` is invoked everywhere user or blob data is rendered.
5. **Bonus:** Always set the `<img src>` to a trusted context if any doubt.

Concretely, in `handleFileChange`, make sure on *any* fail (invalid extension, spoofed file, etc.), we never set `previewImage`. Additionally, make the initial `currentPic` very carefully validated if it's coming from untrusted sources (not originating only from the backend).

In summary:
- Update `handleFileChange` to block any unsafe file at the *earliest* stage, so no unsafe preview is ever set.
- Confirm that `isSafeImageSrc` is sufficiently robust and used before <img> insertion.
- Optionally, add a fallback image or error message rather than previewing any potentially risky uploaded file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
