### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/Components/organization/OrganizationImageUploader.jsx
+++ b/src/Components/organization/OrganizationImageUploader.jsx
@@ -21,8 +21,16 @@ const OrganizationImageUploader = ({
   const handleFileChange = (e) => {
     const file = e.target.files[0];
     if (file) {
-      if (!file.type.startsWith("image/")) {
-        setToast({ message: "Only image files are allowed.", type: "error" });
+      // Disallow SVG files by mime type or extension
+      const allowedMimeTypes = ["image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp"];
+      const fileName = file.name || "";
+      const ext = fileName.split('.').pop().toLowerCase();
+      if (file.type === "image/svg+xml" || ext === "svg") {
+        setToast({ message: "SVG images are not allowed for security reasons.", type: "error" });
+        return;
+      }
+      if (!file.type.startsWith("image/") || !allowedMimeTypes.includes(file.type)) {
+        setToast({ message: "Only PNG, JPEG, JPG, GIF, or WEBP image files are allowed.", type: "error" });
         return;
       }
       // Further check file header to ensure it's really an image (extra safety)
@@ -33,7 +41,7 @@ const OrganizationImageUploader = ({
         for (let i = 0; i < arr.length; i++) {
           header += arr[i].toString(16);
         }
-        // Check PNG/JPEG/GIF magic numbers
+        // Check PNG/JPEG/GIF magic numbers (DISABLE SVG)
         const isImageFile =
           header === "89504e47" || // PNG
           header === "ffd8ffe0" || header === "ffd8ffe1" || header === "ffd8ffe2" || // JPEG
@@ -174,7 +182,7 @@ const OrganizationImageUploader = ({
       (url.startsWith("http://localhost:3000/") ||
         url.startsWith("https://localhost:3000/") ||
         url.startsWith("https://your-trusted-cdn.com/")) &&
-      /\.(png|jpe?g|gif|webp)$/i.test(url)
+      /\.(png|jpe?g|gif|webp)$/i.test(url) // DO NOT ALLOW svg
     )
       return true;
     return false;


### PR DESCRIPTION
Potential fix for [https://github.com/TaskTrial/client/security/code-scanning/2](https://github.com/TaskTrial/client/security/code-scanning/2)

**General Approach**: Prevent possible XSS via uploaded files or untrusted sources by ensuring that only images of certain types (PNG, JPEG, GIF, WEBP) are rendered in the preview, and block loading SVGs entirely (even well-formed ones) as SVG can embed scripts. This reinforces the `handleFileChange` check and the preview logic.

**Detailed Best Fix**:  
Update both the file signature check and the extension check to reject SVG files (as these are most likely to be weaponized by attackers), and make the extension and magic number checking more robust. In `isValidImageUrl`, block SVG images, and in `handleFileChange`, disallow SVG by either MIME type, extension, or magic number. Optionally, for extra safety, render upload previews in a `<canvas>` rather than a direct `<img>` source, but the minimal fix in context is to block SVG.

**What to change**:
- In `handleFileChange`: Add checks to reject SVG files (by MIME type, extension, or magic number).
- In `isValidImageUrl`: Exclude SVG from allowable extensions.
- No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
