### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/Components/Auser/ProfileImageUploader.jsx
+++ b/src/Components/Auser/ProfileImageUploader.jsx
@@ -19,7 +19,42 @@ const ProfileImageUploader = ({
   const userData = useSelector((state) => state.user);
   const userId = userData.id;
 
-  const handleFileChange = (e) => {
+  // Helper to read file and validate its magic number (content signature)
+  async function isFileImageBySignature(file) {
+    return new Promise((resolve) => {
+      const fileSigs = {
+        jpg: [[0xFF, 0xD8, 0xFF]],
+        png: [[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]],
+        gif: [[0x47, 0x49, 0x46, 0x38, 0x37, 0x61], [0x47, 0x49, 0x46, 0x38, 0x39, 0x61]],
+        bmp: [[0x42, 0x4D]],
+        webp: [[0x52, 0x49, 0x46, 0x46]] // Need to additionally check `WEBP` in bytes 8-11
+      };
+      const reader = new FileReader();
+      reader.onloadend = function(e) {
+        const arr = new Uint8Array(e.target.result);
+        // JPEG
+        if (arr.length >= 3 && arr[0] === 0xFF && arr[1] === 0xD8 && arr[2] === 0xFF) return resolve(true);
+        // PNG
+        if (arr.length >= 8 &&
+          arr[0] === 0x89 && arr[1] === 0x50 && arr[2] === 0x4E && arr[3] === 0x47 &&
+          arr[4] === 0x0D && arr[5] === 0x0A && arr[6] === 0x1A && arr[7] === 0x0A) return resolve(true);
+        // GIF
+        if (arr.length >= 6 &&
+          ((arr[0] === 0x47 && arr[1] === 0x49 && arr[2] === 0x46 && arr[3] === 0x38 &&
+            ((arr[4] === 0x37 && arr[5] === 0x61) || (arr[4] === 0x39 && arr[5] === 0x61))))) return resolve(true);
+        // BMP
+        if (arr.length >= 2 && arr[0] === 0x42 && arr[1] === 0x4D) return resolve(true);
+        // WEBP (RIFF....WEBP)
+        if (arr.length >= 12 && arr[0] === 0x52 && arr[1] === 0x49 && arr[2] === 0x46 && arr[3] === 0x46 &&
+                              arr[8] === 0x57 && arr[9] === 0x45 && arr[10] === 0x42 && arr[11] === 0x50) return resolve(true);
+        resolve(false);
+      };
+      // Read enough bytes for all magic headers (12 is enough for all above types)
+      reader.readAsArrayBuffer(file.slice(0, 12));
+    });
+  }
+
+  const handleFileChange = async (e) => {
     const file = e.target.files[0];
     if (file) {
       // Only allow safe image MIME types (extra defense)
@@ -46,6 +81,18 @@ const ProfileImageUploader = ({
           setToast({
             type: "error",
             message: "Only JPEG, PNG, GIF, BMP, or WEBP images are allowed for profile pictures.",
+          });
+        return;
+      }
+      // Now check signature
+      const isImageSignature = await isFileImageBySignature(file);
+      if (!isImageSignature) {
+        setSelectedFile(null);
+        setPreviewImage(null);
+        setToast &&
+          setToast({
+            type: "error",
+            message: "The selected file is not a valid image. Only JPEG, PNG, GIF, BMP, WEBP images are supported.",
           });
         return;
       }


### PR DESCRIPTION
Potential fix for [https://github.com/TaskTrial/client/security/code-scanning/1](https://github.com/TaskTrial/client/security/code-scanning/1)

The optimal fix is to perform "content sniffing" of the uploaded file, not just trusting file extension and MIME type. This means, before using `URL.createObjectURL(file)` and setting it as `previewImage`, we should verify using JavaScript that the actual bytes of the file match the expected patterns (magic numbers) for images like JPEG, PNG, GIF, BMP, WEBP. To do this:
- Add a helper function to read the file's first N bytes (using the FileReader API) and check the magic numbers for allowed types.
- In `handleFileChange`, after initial checks, use this function to further validate the file (asynchronously). Only if the file passes, call `setSelectedFile` and `setPreviewImage`.
- Update relevant code in `handleFileChange` to handle async code and error cases.

This will ensure that even if attackers manage to fool the client with a wrong extension/type, only a true safe image file will be allowed.  
Most changes will be within the `handleFileChange` function and new helper code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
